### PR TITLE
Refactor logging

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -94,20 +94,25 @@ jobs:
           # qqqq now were dry running do we need to error handle?
           set +e
           # Due to dry-run need to catch error differently : SEMVER_OUTPUT_RAW=$(npx semantic-release --dry-run 2>&1) || STATUS=$?
+          echo "running semantic-release"
           SEMVER_OUTPUT_RAW=$(npx semantic-release --dry-run 2>&1)
           STATUS=$?
+          echo "status = $STATUS"
           set -e
           echo "$SEMVER_OUTPUT_RAW"
 
           # 0 not exclusively due to no version bump so check output
           if [ "${STATUS:-0}" -ne 0 ]; then
-            if echo "$SEMVER_OUTPUT_RAW" | grep -q "No release published"; then
+            echo "in if status 0"
+            if echo "$SEMVER_OUTPUT_RAW" | grep -q "There are no relevant changes"; then
+              echo "in if no release published"
               # No new version, but we can find the current version
               echo "No new version required getting current version from git tags"
               DEV_SEMVER_VERSION=$(git describe --tags --abbrev=0 2>/dev/null || echo "0.0.0-version-not-found") # last git tag so if multiple bumps in other branches making package version there will be some discrepancy but the purpose is distinguishing them for dev purposes.
               echo "DEV_SEMVER_VERSION = $DEV_SEMVER_VERSION"
               exit 0   # treat as success code didnt fail there just was no version increment required          
             else
+              echo "in else no release published"
               exit $STATUS   # real error → fail pipeline
             fi
           else

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -118,6 +118,7 @@ jobs:
           else
             # Get version include prerelease tag
             # Dry run returns different text DEV_SEMVER_VERSION=$(echo "$OUTPUT" | grep -oP 'Published release \K[^\s]+')
+            echo "in else so status was zero for error"
             DEV_SEMVER_VERSION=$(echo "$SEMVER_OUTPUT_RAW" | grep -oP 'Dry run: would publish version \K[^\s]+')
             echo "DEV_SEMVER_VERSION = $DEV_SEMVER_VERSION"
             echo "version change required true"

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -167,8 +167,8 @@ jobs:
           #set -e
           echo "$SEMVER_OUTPUT_RAW"          
           
-          # Get fallback version
-          FALLBACK_VERSION=$(git describe --tags --abbrev=0 2>/dev/null || echo "0.0.0-version-not-found")
+          # Get fallback version by grabbing the git tag dropping the first character, the "v", or use hardcoded fallback
+          FALLBACK_VERSION=$(git describe --tags --abbrev=0 2>/dev/null | cut -c2- || echo "0.0.0-version-not-found")
           echo "FALLBACK_VERSION=$FALLBACK_VERSION"
     
           set +e
@@ -196,9 +196,6 @@ jobs:
             echo "DEV_SEMVER_VERSION=$DEV_SEMVER_VERSION"
             echo "DEV_SEMVER_VERSION=$DEV_SEMVER_VERSION" >> $GITHUB_ENV
           fi
-
-
-
           
       - name: Rename Semver Version with branch date time dev
         id: set_dev_semantic_version

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -88,6 +88,7 @@ jobs:
       #configured with .releaseserc
       # qqqq if we are not versioning the repo why arnt we dry running
       - name: Run dev semantic version (None Blocking)
+        id: detect_semantic_version
         run: |
 
           #set +e
@@ -115,18 +116,19 @@ jobs:
           if echo "$SEMVER_OUTPUT_RAW" | grep -q 'There are no relevant changes'; then
             DEV_SEMVER_VERSION="$FALLBACK_VERSION"
             echo "No relevant changes found - DEV_SEMVER_VERSION=$DEV_SEMVER_VERSION"
+            echo "DEV_SEMVER_VERSION=$DEV_SEMVER_VERSION" >> $GITHUB_ENV
           elif echo "$SEMVER_OUTPUT_RAW" | grep -q 'Dry run: would publish version'; then
           # Extract the actual version
             DEV_SEMVER_VERSION=$(echo "$SEMVER_OUTPUT_RAW" | grep -oP 'Dry run: would publish version \K[^\s]+' || echo "extract-failed")
             echo "Version change detected - DEV_SEMVER_VERSION=$DEV_SEMVER_VERSION"
             echo "version change required true"
+            echo "DEV_SEMVER_VERSION=$DEV_SEMVER_VERSION" >> $GITHUB_ENV
           else
             echo "Neither 'no changes' nor 'would publish' found, using fallback"
             DEV_SEMVER_VERSION="$FALLBACK_VERSION"
             echo "DEV_SEMVER_VERSION=$DEV_SEMVER_VERSION"
+            echo "DEV_SEMVER_VERSION=$DEV_SEMVER_VERSION" >> $GITHUB_ENV
           fi
-    
-          exit 0
 
           # 0 not exclusively due to no version bump so check output
           # dry release seems not to error 1 qqqq!
@@ -191,7 +193,8 @@ jobs:
       - name: Rename Semver Version with branch date time dev
         id: set_dev_semantic_version
         run: |        
-          echo "Dev Semantic Release Output $DEV_SEMVER_VERSION"
+          DEV_SEMVER_VERSION="${{ steps.detect_semantic_version.outputs.DEV_SEMVER_VERSION }}"
+          echo "Dev Semantic Version Output = $DEV_SEMVER_VERSION"
 
           # In development, we always package and update the website—even if there’s no version change.
           # This ensures the CI process runs consistently and the latest code is deployed.

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -89,42 +89,70 @@ jobs:
       # qqqq if we are not versioning the repo why arnt we dry running
       - name: Run dev semantic version (None Blocking)
         run: |
-          # Set pipefail so we can check if pipefail is semantic-release classifying no version bump required as an error
-          # qqqq set -o pipefail
-          # qqqq now were dry running do we need to error handle?
-          set +e
+
+          #set +e
           # Due to dry-run need to catch error differently : SEMVER_OUTPUT_RAW=$(npx semantic-release --dry-run 2>&1) || STATUS=$?
           echo "running semantic-release"
           SEMVER_OUTPUT_RAW=$(npx semantic-release --dry-run 2>&1)
           STATUS=$?
           echo "status = $STATUS"
+          #set -e
+          echo "$SEMVER_OUTPUT_RAW"          
+          
+          # Get fallback version
+          FALLBACK_VERSION=$(git describe --tags --abbrev=0 2>/dev/null || echo "0.0.0-version-not-found")
+          echo "FALLBACK_VERSION=$FALLBACK_VERSION"
+    
+          set +e
+          # Check what's in the output
+          GREP_NO_CHANGES=$(echo "$SEMVER_OUTPUT_RAW" | grep -q 'There are no relevant changes' && echo "true" || echo "false")
+          GREP_WOULD_PUBLISH=$(echo "$SEMVER_OUTPUT_RAW" | grep -q 'Dry run: would publish version' && echo "true" || echo "false")
+          echo "GREP_NO_CHANGES=$GREP_NO_CHANGES"
+          echo "GREP_WOULD_PUBLISH=$GREP_WOULD_PUBLISH"
           set -e
-          echo "$SEMVER_OUTPUT_RAW"
+          
+          # Check for no changes and set DEV_SEMVER_VERSION accordingly
+          if echo "$SEMVER_OUTPUT_RAW" | grep -q 'There are no relevant changes'; then
+            DEV_SEMVER_VERSION="$FALLBACK_VERSION"
+            echo "No relevant changes found - DEV_SEMVER_VERSION=$DEV_SEMVER_VERSION"
+          elif echo "$SEMVER_OUTPUT_RAW" | grep -q 'Dry run: would publish version'; then
+          # Extract the actual version
+            DEV_SEMVER_VERSION=$(echo "$SEMVER_OUTPUT_RAW" | grep -oP 'Dry run: would publish version \K[^\s]+' || echo "extract-failed")
+            echo "Version change detected - DEV_SEMVER_VERSION=$DEV_SEMVER_VERSION"
+            echo "version change required true"
+          else
+            echo "Neither 'no changes' nor 'would publish' found, using fallback"
+            DEV_SEMVER_VERSION="$FALLBACK_VERSION"
+            echo "DEV_SEMVER_VERSION=$DEV_SEMVER_VERSION"
+          fi
+    
+          exit 0
 
           # 0 not exclusively due to no version bump so check output
-          if [ "${STATUS:-0}" -ne 0 ]; then
-            echo "in if status 0"
-            if echo "$SEMVER_OUTPUT_RAW" | grep -q "There are no relevant changes"; then
-              echo "in if no release published"
-              # No new version, but we can find the current version
-              echo "No new version required getting current version from git tags"
-              DEV_SEMVER_VERSION=$(git describe --tags --abbrev=0 2>/dev/null || echo "0.0.0-version-not-found") # last git tag so if multiple bumps in other branches making package version there will be some discrepancy but the purpose is distinguishing them for dev purposes.
-              echo "DEV_SEMVER_VERSION = $DEV_SEMVER_VERSION"
-              exit 0   # treat as success code didnt fail there just was no version increment required          
-            else
-              echo "in else no release published"
-              exit $STATUS   # real error → fail pipeline
-            fi
-          else
-            # Get version include prerelease tag
-            # Dry run returns different text DEV_SEMVER_VERSION=$(echo "$OUTPUT" | grep -oP 'Published release \K[^\s]+')
-            echo "in else so status was zero for error"
-            DEV_SEMVER_VERSION=$(echo "$SEMVER_OUTPUT_RAW" | grep -oP 'Dry run: would publish version \K[^\s]+')
-            echo "DEV_SEMVER_VERSION = $DEV_SEMVER_VERSION"
-            echo "version change required true"
-            # Just because weve been handling errors
-            exit 0
-          fi
+          # dry release seems not to error 1 qqqq!
+          # if [ "${STATUS:-0}" -ne 0 ]; then
+            # echo "in if status 0"
+            # if echo "$SEMVER_OUTPUT_RAW" | grep -q "There are no relevant changes"; then
+              # echo "in if no release published"
+              # # No new version, but we can find the current version
+              # echo "No new version required getting current version from git tags"
+              # DEV_SEMVER_VERSION=$(git describe --tags --abbrev=0 2>/dev/null || echo "0.0.0-version-not-found") # last git tag so if multiple bumps in other branches making package version there will be some discrepancy but the purpose is distinguishing them for dev purposes.
+              # echo "DEV_SEMVER_VERSION = $DEV_SEMVER_VERSION"
+              # exit 0   # treat as success code didnt fail there just was no version increment required          
+            # else
+              # echo "in else no release published"
+              # exit $STATUS   # real error → fail pipeline
+            # fi
+          # else
+            # # Get version include prerelease tag
+            # # Dry run returns different text DEV_SEMVER_VERSION=$(echo "$OUTPUT" | grep -oP 'Published release \K[^\s]+')
+            # echo "in else so status was zero for error"
+            # DEV_SEMVER_VERSION=$(echo "$SEMVER_OUTPUT_RAW" | grep -oP 'Dry run: would publish version \K[^\s]+')
+            # echo "DEV_SEMVER_VERSION = $DEV_SEMVER_VERSION"
+            # echo "version change required true"
+            # # Just because weve been handling errors
+            # exit 0
+          # fi
       
       
       # qqqq - name: Run semantic version (None Blocking)

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -53,6 +53,73 @@ jobs:
       
 
 
+
+
+
+####### qqqq
+          # 0 not exclusively due to no version bump so check output
+          # dry release seems not to error 1 qqqq!
+          # if [ "${STATUS:-0}" -ne 0 ]; then
+            # echo "in if status 0"
+            # if echo "$SEMVER_OUTPUT_RAW" | grep -q "There are no relevant changes"; then
+              # echo "in if no release published"
+              # # No new version, but we can find the current version
+              # echo "No new version required getting current version from git tags"
+              # DEV_SEMVER_VERSION=$(git describe --tags --abbrev=0 2>/dev/null || echo "0.0.0-version-not-found") # last git tag so if multiple bumps in other branches making package version there will be some discrepancy but the purpose is distinguishing them for dev purposes.
+              # echo "DEV_SEMVER_VERSION = $DEV_SEMVER_VERSION"
+              # exit 0   # treat as success code didnt fail there just was no version increment required          
+            # else
+              # echo "in else no release published"
+              # exit $STATUS   # real error → fail pipeline
+            # fi
+          # else
+            # # Get version include prerelease tag
+            # # Dry run returns different text DEV_SEMVER_VERSION=$(echo "$OUTPUT" | grep -oP 'Published release \K[^\s]+')
+            # echo "in else so status was zero for error"
+            # DEV_SEMVER_VERSION=$(echo "$SEMVER_OUTPUT_RAW" | grep -oP 'Dry run: would publish version \K[^\s]+')
+            # echo "DEV_SEMVER_VERSION = $DEV_SEMVER_VERSION"
+            # echo "version change required true"
+            # # Just because weve been handling errors
+            # exit 0
+          # fi
+      
+      
+      # qqqq - name: Run semantic version (None Blocking)
+        # run: |
+          # # If no version is required we can get an error so here we handle it
+          # set +e
+          
+          # SEMVER_OUTPUT_RAW=$(npx semantic-release)
+          # echo "Raw SEMVER_OUTPUT_RAW=$SEMVER_OUTPUT_RAW"
+          
+          # SEMVER_OUTPUT=$(echo "$SEMVER_OUTPUT_RAW" | grep -oP 'Published release \K[^\s]+')
+
+          # # In development, we always package and update the website—even if there’s no version change.
+          # # This ensures the CI process runs consistently and the latest code is deployed.
+          # # It's especially useful when squashing commits, as it guarantees the package is still rebuilt and published.
+          # echo "Packaging and updating the website in development, even without version changes, to ensure consistent CI behavior and updated packages after squashed commits."
+          
+          # STATUS=$?
+          # if [ -z "$SEMVER_OUTPUT" ]; then
+            # SEMVER_OUTPUT=$(echo "$SEMVER_OUTPUT_RAW" | grep -oP 'Found git tag v\K[^\s]+')
+            # # Note: If Semver falls back to using a Git tag, it will pick the most recent one.
+            # # This tag may not belong to the current branch, so the result isn't guaranteed to reflect the latest changes on this branch.
+            # echo "Semver fallback: using latest Git tag, which may not be from the current branch."
+          # fi
+          
+          # if [ -z "$SEMVER_OUTPUT" ]; then
+            # SEMVER_OUTPUT="0.0.0"
+            # echo "No semantic version or tag, defaulting to 0.0.0 $SEMVER_OUTPUT"
+          # fi
+         
+          # # Export the result to the environment
+          # echo "SEMVER_OUTPUT=$SEMVER_OUTPUT" >> $GITHUB_ENV
+          # set -e
+################
+
+
+
+
   # Now we've done due diligence
   # The checks have been allowed to run if the workflow fails so if there a multiple fails we know. 
   # We do not proceed from the point if there is a fail.
@@ -130,70 +197,13 @@ jobs:
             echo "DEV_SEMVER_VERSION=$DEV_SEMVER_VERSION" >> $GITHUB_ENV
           fi
 
-          # 0 not exclusively due to no version bump so check output
-          # dry release seems not to error 1 qqqq!
-          # if [ "${STATUS:-0}" -ne 0 ]; then
-            # echo "in if status 0"
-            # if echo "$SEMVER_OUTPUT_RAW" | grep -q "There are no relevant changes"; then
-              # echo "in if no release published"
-              # # No new version, but we can find the current version
-              # echo "No new version required getting current version from git tags"
-              # DEV_SEMVER_VERSION=$(git describe --tags --abbrev=0 2>/dev/null || echo "0.0.0-version-not-found") # last git tag so if multiple bumps in other branches making package version there will be some discrepancy but the purpose is distinguishing them for dev purposes.
-              # echo "DEV_SEMVER_VERSION = $DEV_SEMVER_VERSION"
-              # exit 0   # treat as success code didnt fail there just was no version increment required          
-            # else
-              # echo "in else no release published"
-              # exit $STATUS   # real error → fail pipeline
-            # fi
-          # else
-            # # Get version include prerelease tag
-            # # Dry run returns different text DEV_SEMVER_VERSION=$(echo "$OUTPUT" | grep -oP 'Published release \K[^\s]+')
-            # echo "in else so status was zero for error"
-            # DEV_SEMVER_VERSION=$(echo "$SEMVER_OUTPUT_RAW" | grep -oP 'Dry run: would publish version \K[^\s]+')
-            # echo "DEV_SEMVER_VERSION = $DEV_SEMVER_VERSION"
-            # echo "version change required true"
-            # # Just because weve been handling errors
-            # exit 0
-          # fi
-      
-      
-      # qqqq - name: Run semantic version (None Blocking)
-        # run: |
-          # # If no version is required we can get an error so here we handle it
-          # set +e
-          
-          # SEMVER_OUTPUT_RAW=$(npx semantic-release)
-          # echo "Raw SEMVER_OUTPUT_RAW=$SEMVER_OUTPUT_RAW"
-          
-          # SEMVER_OUTPUT=$(echo "$SEMVER_OUTPUT_RAW" | grep -oP 'Published release \K[^\s]+')
 
-          # # In development, we always package and update the website—even if there’s no version change.
-          # # This ensures the CI process runs consistently and the latest code is deployed.
-          # # It's especially useful when squashing commits, as it guarantees the package is still rebuilt and published.
-          # echo "Packaging and updating the website in development, even without version changes, to ensure consistent CI behavior and updated packages after squashed commits."
-          
-          # STATUS=$?
-          # if [ -z "$SEMVER_OUTPUT" ]; then
-            # SEMVER_OUTPUT=$(echo "$SEMVER_OUTPUT_RAW" | grep -oP 'Found git tag v\K[^\s]+')
-            # # Note: If Semver falls back to using a Git tag, it will pick the most recent one.
-            # # This tag may not belong to the current branch, so the result isn't guaranteed to reflect the latest changes on this branch.
-            # echo "Semver fallback: using latest Git tag, which may not be from the current branch."
-          # fi
-          
-          # if [ -z "$SEMVER_OUTPUT" ]; then
-            # SEMVER_OUTPUT="0.0.0"
-            # echo "No semantic version or tag, defaulting to 0.0.0 $SEMVER_OUTPUT"
-          # fi
-         
-          # # Export the result to the environment
-          # echo "SEMVER_OUTPUT=$SEMVER_OUTPUT" >> $GITHUB_ENV
-          # set -e
 
           
       - name: Rename Semver Version with branch date time dev
         id: set_dev_semantic_version
         run: |        
-          DEV_SEMVER_VERSION="${{ steps.detect_semantic_version.outputs.DEV_SEMVER_VERSION }}"
+          # DEV_SEMVER_VERSION="${{ steps.detect_semantic_version.outputs.DEV_SEMVER_VERSION }}"
           echo "Dev Semantic Version Output = $DEV_SEMVER_VERSION"
 
           # In development, we always package and update the website—even if there’s no version change.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,7 @@ jobs:
           # Set error to not instantly fail so we can check if error is semantic-release classifying no version bump required as an error
           set +e
           OUTPUT=$(npx semantic-release 2>&1) || STATUS=$?
+          echo "status = $STATUS"
           set -e
           echo "$OUTPUT"
 


### PR DESCRIPTION
# PR Template

### JIRA/RoadMap
_Provide your ticket number
[TD-####](https://hee-tis.atlassian.net/browse/TD-####)
[Git Ticket Board](https://github.com/orgs/TechnologyEnhancedLearning/projects/9)[Ticket Board](https://github.com/orgs/TechnologyEnhancedLearning/projects/9)
[Git Ticket](https://github.com/TechnologyEnhancedLearning/TELBlazor/issues/42)

### Description
_Describe what has changed and how that will affect the app. If relevant, add links to any sources/documentation you used. Highlight anything unusual and give people context around particular decisions._

### Resulting Dev package
_Your dev generated package name and reference
[TELBlazor published packages](https://github.com/TechnologyEnhancedLearning/TELBlazor/pkgs/nuget/TELBlazor.Components)
Dev packages are follow by branch name -branch-name and are generated
Will this code change result in a production package version increase 

### Screenshots
_Paste screenshots for all views created or changed: mobile, tablet and desktop, wave analyser showing no errors._

### Linked package consumer tasks
[TD-####](https://hee-tis.atlassian.net/browse/TD-####)
[ ] Consumers also need to update nhsuk css dependency to : __put_required_nhsuk_semantic_version_here__

### Logging
_Provide description of any component scoped logging or specific level logging to check

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Provided showcase example of component if applicable
- [ ] Added appropriate logging and scopped logging reporting in appsettings for component if applicable
- [ ] Updated readme documentation
- [ ] Updated showcase documentation for component
- [ ] I have locally run tests against a local package (not just using project reference)
- [ ] Used a browser set to No Js before using it to locally run and test changes (recommend brave as second browser)
- [ ] Written Unit tests with accesibility syntax
- [ ] Written E2E tests with accesibility syntax and accessibility test
- [ ] Tested components with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] [Check code coverage](https://technologyenhancedlearning.github.io/TELBlazor-CodeReport/) or locally with local report generation
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the PR and need  to be tested to ensure nothing is broken
- [ ] Tested in [Dev Showcase](https://technologyenhancedlearning.github.io/TELBlazor-DevShowCase/) (including logging by using log level switcher)
- [ ] Scanned over my pull request and commented with any useful explanations/questions to reviewers
- [ ] Scanned over cicd warnings

---
### Peer Reviewers and Assignee checks before Approval
- [ ] Feedback has been provided
- [ ] Project has been run locally (you can provide pr feedback via vs if desired)
- [ ] Locally checked in browser set to No Js from before load (recommend Brave with no js settings)
- [ ] [Dev Showcase](https://technologyenhancedlearning.github.io/TELBlazor-DevShowCase/) was checked and it was checked the package number matched the PR
- [ ] In Dev Showcase checked against different logging levels if applicable (use log level switcher to change level)
- [ ] All conversations have been responded to (emoji will do) and marked resolved
- [ ] Out of scope code observations have been recorded to inform future tasks
- [ ] Common questions / Architectural explanations decisions from PR documented
- [ ] [Check code coverage](https://technologyenhancedlearning.github.io/TELBlazor-CodeReport/)
- [ ] Should E2E or Unit test have been added
- [ ] If the published dev package is linked and used in tandom with a package consumer task is it working locally (Not a hard requirement but useful in case changes required)
- [ ] Checked component readme in Showcase

---
### Post PR Intentions and Actions
- [ ] On merge will someone check [Prod Showcase](https://technologyenhancedlearning.github.io/TELBlazor/)
- [ ] Tick yes if consuming projects need a version bump and/or code changes to take advantage of new components etc
- [ ] If there is a linked consuming project task has the task assignee, or task been updated to know the package is available as a dev/prod version and been provided the version number.