### PR TITLE
chore(release): not getting error 0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,13 +56,6 @@ jobs:
       - name: run semantic release
         id: set_semantic_version
         run: |
-          # qqqq
-          # Set error to not instantly fail so we can check if error is semantic-release classifying no version bump required as an error
-          # set +e
-          # OUTPUT=$(npx semantic-release 2>&1) || STATUS=$?
-          # echo "status = $STATUS"
-          # set -e
-          # echo "$OUTPUT"
           
           echo "running semantic-release"
           SEMVER_OUTPUT_RAW=$(npx semantic-release 2>&1)
@@ -70,61 +63,64 @@ jobs:
           echo "status = $STATUS"
           echo "$SEMVER_OUTPUT_RAW"     
           
-          # # Check for no changes and set SEMVER_VERSION accordingly
-          # if echo "$SEMVER_OUTPUT_RAW" | grep -q 'There are no relevant changes'; then
-            # DEV_SEMVER_VERSION="$FALLBACK_VERSION"
-            # echo "No relevant changes found - DEV_SEMVER_VERSION=$DEV_SEMVER_VERSION"
-            # echo "DEV_SEMVER_VERSION=$DEV_SEMVER_VERSION" >> $GITHUB_ENV
-          # # Check if version bump expected
-          # elif echo "$SEMVER_OUTPUT_RAW" | grep -q 'Dry run: would publish version'; then
-          # # Extract the actual version
-            # DEV_SEMVER_VERSION=$(echo "$SEMVER_OUTPUT_RAW" | grep -oP 'Dry run: would publish version \K[^\s]+' || echo "extract-failed")
-            # echo "Version change detected - DEV_SEMVER_VERSION=$DEV_SEMVER_VERSION"
-            # echo "version change required true"
-            # echo "DEV_SEMVER_VERSION=$DEV_SEMVER_VERSION" >> $GITHUB_ENV
-            # # Fallback
-          # else
-            # echo " ⚠️ Neither 'no changes' nor 'would publish' found. (using fallback)."
-            # DEV_SEMVER_VERSION="$FALLBACK_VERSION"
-            # echo "DEV_SEMVER_VERSION=$DEV_SEMVER_VERSION"
-            # echo "DEV_SEMVER_VERSION=$DEV_SEMVER_VERSION" >> $GITHUB_ENV
-          # fi
+          # Check for no changes and set SEMVER_VERSION accordingly
+          if echo "$SEMVER_OUTPUT_RAW" | grep -q 'There are no relevant changes'; then
+            echo "No relevant changes found"
+            SEMVER_CHANGED=false
+            echo "Changes do not warrant a version change. gh_pages and packages won't be updated."
+            echo "semantic-version-change-required=$SEMVER_CHANGED" >> $GITHUB_OUTPUT
+            echo "Changes do not warrant a version change. gh_pages and packages won't be updated."
+          # Check if version bump expected
+          elif echo "$SEMVER_OUTPUT_RAW" | grep -q 'Published release'; then
+            # Extract the actual version, if it fails here we want to know
+            SEMVER_VERSION=$(echo "$SEMVER_OUTPUT_RAW" | grep -oP 'Published release \K[\d.]+')
+            echo "Version change detected - SEMVER_VERSION=$SEMVER_VERSION"
+            echo "version change required true"
+            SEMVER_CHANGED=true
+            echo "semantic-release-version=$SEMVER_VERSION" >> $GITHUB_OUTPUT
+            echo "semantic-version-change-required=$SEMVER_CHANGED" >> $GITHUB_OUTPUT
+          else
+            echo "⚠️ Semver-release not successfully parsed ⚠️" 
+            echo "Output did not match expected patterns"
+            echo "Raw output was: $SEMVER_OUTPUT_RAW"
+            exit 1
+          fi
           
 
           # 0 not exclusively due to no version bump so check output
-          if [ "${STATUS:-0}" -ne 0 ]; then
-            echo "Status code is not 0"
-            if echo "$SEMVER_OUTPUT_RAW" | grep -q "No release published"; then
-              echo "no version change detected"
-              # No new version, but we can find the current version
-              #echo "No new version required getting current version from git tags"
-              #SEMVER_VERSION=$(git describe --tags --abbrev=0 2>/dev/null || echo "0.0.0-version-placeholder") # last git tag
-              echo "semantic-release-version=$SEMVER_VERSION"
-              SEMVER_CHANGED=false
-              echo "Changes do not warrant a version change. gh_pages and packages won't be updated."
-              #echo "semantic-release-version=$SEMVER_VERSION" >> $GITHUB_OUTPUT
-              echo "semantic-version-change-required=$SEMVER_CHANGED" >> $GITHUB_OUTPUT
-              exit 0   # treat as success code didnt fail there just was no version increment required          
-            else
-              echo "exit using status outcome of semver"
-              exit $STATUS   # real error → fail pipeline
-            fi
-          else
-            echo "grep semver version"
-            SEMVER_VERSION=$(echo "$SEMVER_OUTPUT_RAW" | grep -oP 'Published release \K[\d.]+')
-            echo "semantic-release-version=$SEMVER_VERSION"
-            # qqqq VERSION=$(echo "$OUTPUT" | grep "Published release" | awk '{print $NF}') - AI suggestion try if issues
-            # awk is a text-processing tool that splits each line into fields using whitespace by default.
-            # $NF is a special variable in awk that means “the last field” of the current line.
-            # print $NF prints just that last field.
-            SEMVER_CHANGED=true
-            echo "semantic-version-change-required=$SEMVER_CHANGED"
-            echo "version change required true"
-            echo "semantic-release-version=$SEMVER_VERSION" >> $GITHUB_OUTPUT
-            echo "semantic-version-change-required=$SEMVER_CHANGED" >> $GITHUB_OUTPUT
-            # Just because weve been handling errors
-            exit 0
-          fi
+          # if [ "${STATUS:-0}" -ne 0 ]; then
+            # echo "Status code is not 0"
+            # if echo "$SEMVER_OUTPUT_RAW" | grep -q "No release published"; then
+              # echo "no version change detected"
+              # # No new version, but we can find the current version
+              # #echo "No new version required getting current version from git tags"
+              # #SEMVER_VERSION=$(git describe --tags --abbrev=0 2>/dev/null || echo "0.0.0-version-placeholder") # last git tag
+              # echo "semantic-release-version=$SEMVER_VERSION"
+              # SEMVER_CHANGED=false
+              # echo "Changes do not warrant a version change. gh_pages and packages won't be updated."
+              # #echo "semantic-release-version=$SEMVER_VERSION" >> $GITHUB_OUTPUT
+              # echo "semantic-version-change-required=$SEMVER_CHANGED" >> $GITHUB_OUTPUT
+              # exit 0   # treat as success code didnt fail there just was no version increment required          
+            # else
+              # echo "exit using status outcome of semver"
+              # exit $STATUS   # real error → fail pipeline
+            # fi
+          # else
+            # echo "grep semver version"
+            # SEMVER_VERSION=$(echo "$SEMVER_OUTPUT_RAW" | grep -oP 'Published release \K[\d.]+')
+            # echo "semantic-release-version=$SEMVER_VERSION"
+            # # qqqq VERSION=$(echo "$OUTPUT" | grep "Published release" | awk '{print $NF}') - AI suggestion try if issues
+            # # awk is a text-processing tool that splits each line into fields using whitespace by default.
+            # # $NF is a special variable in awk that means “the last field” of the current line.
+            # # print $NF prints just that last field.
+            # SEMVER_CHANGED=true
+            # echo "semantic-version-change-required=$SEMVER_CHANGED"
+            # echo "version change required true"
+            # echo "semantic-release-version=$SEMVER_VERSION" >> $GITHUB_OUTPUT
+            # echo "semantic-version-change-required=$SEMVER_CHANGED" >> $GITHUB_OUTPUT
+            # # Just because weve been handling errors
+            # exit 0
+          # fi
           
       #configured with .releaseserc
       # qqqq- name: Run semantic release


### PR DESCRIPTION
# PR Template

### JIRA/RoadMap
_Provide your ticket number
[TD-####](https://hee-tis.atlassian.net/browse/TD-####)
[Git Ticket Board](https://github.com/orgs/TechnologyEnhancedLearning/projects/9)[Ticket Board](https://github.com/orgs/TechnologyEnhancedLearning/projects/9)
[Git Ticket](https://github.com/TechnologyEnhancedLearning/TELBlazor/issues/42)

### Description
_Describe what has changed and how that will affect the app. If relevant, add links to any sources/documentation you used. Highlight anything unusual and give people context around particular decisions._

### Resulting Dev package
_Your dev generated package name and reference
[TELBlazor published packages](https://github.com/TechnologyEnhancedLearning/TELBlazor/pkgs/nuget/TELBlazor.Components)
Dev packages are follow by branch name -branch-name and are generated
Will this code change result in a production package version increase 

### Screenshots
_Paste screenshots for all views created or changed: mobile, tablet and desktop, wave analyser showing no errors._

### Linked package consumer tasks
[TD-####](https://hee-tis.atlassian.net/browse/TD-####)
[ ] Consumers also need to update nhsuk css dependency to : __put_required_nhsuk_semantic_version_here__

### Logging
_Provide description of any component scoped logging or specific level logging to check

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Provided showcase example of component if applicable
- [ ] Added appropriate logging and scopped logging reporting in appsettings for component if applicable
- [ ] Updated readme documentation
- [ ] Updated showcase documentation for component
- [ ] I have locally run tests against a local package (not just using project reference)
- [ ] Used a browser set to No Js before using it to locally run and test changes (recommend brave as second browser)
- [ ] Written Unit tests with accesibility syntax
- [ ] Written E2E tests with accesibility syntax and accessibility test
- [ ] Tested components with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] [Check code coverage](https://technologyenhancedlearning.github.io/TELBlazor-CodeReport/) or locally with local report generation
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the PR and need  to be tested to ensure nothing is broken
- [ ] Tested in [Dev Showcase](https://technologyenhancedlearning.github.io/TELBlazor-DevShowCase/) (including logging by using log level switcher)
- [ ] Scanned over my pull request and commented with any useful explanations/questions to reviewers
- [ ] Scanned over cicd warnings

---
### Peer Reviewers and Assignee checks before Approval
- [ ] Feedback has been provided
- [ ] Project has been run locally (you can provide pr feedback via vs if desired)
- [ ] Locally checked in browser set to No Js from before load (recommend Brave with no js settings)
- [ ] [Dev Showcase](https://technologyenhancedlearning.github.io/TELBlazor-DevShowCase/) was checked and it was checked the package number matched the PR
- [ ] In Dev Showcase checked against different logging levels if applicable (use log level switcher to change level)
- [ ] All conversations have been responded to (emoji will do) and marked resolved
- [ ] Out of scope code observations have been recorded to inform future tasks
- [ ] Common questions / Architectural explanations decisions from PR documented
- [ ] [Check code coverage](https://technologyenhancedlearning.github.io/TELBlazor-CodeReport/)
- [ ] Should E2E or Unit test have been added
- [ ] If the published dev package is linked and used in tandom with a package consumer task is it working locally (Not a hard requirement but useful in case changes required)
- [ ] Checked component readme in Showcase

---
### Post PR Intentions and Actions
- [ ] On merge will someone check [Prod Showcase](https://technologyenhancedlearning.github.io/TELBlazor/)
- [ ] Tick yes if consuming projects need a version bump and/or code changes to take advantage of new components etc
- [ ] If there is a linked consuming project task has the task assignee, or task been updated to know the package is available as a dev/prod version and been provided the version number.